### PR TITLE
Site to site vpn

### DIFF
--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -1,0 +1,25 @@
+name: cftest
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up ruby 2.7
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.7.x
+    - name: install gems
+      run: gem install cfhighlander rspec 
+    - name: set cfndsl spec
+      run: cfndsl -u
+    - name: cftest
+      run: rspec
+      env:
+        AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: ap-southeast-2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+out/
+reports/

--- a/site-to-site-vpn.cfhighlander.rb
+++ b/site-to-site-vpn.cfhighlander.rb
@@ -1,0 +1,13 @@
+CfhighlanderTemplate do
+  Name 'site-to-site-vpn'
+  
+  Parameters do
+    ComponentParam 'EnvironmentName', 'dev', isGlobal: true
+    ComponentParam 'EnvironmentType', 'development', allowedValues: ['development','production'], isGlobal: true
+    ComponentParam 'VPCId', type: 'AWS::EC2::VPC::Id'
+    ComponentParam 'CGWIpAddress', type: 'String'
+    ComponentParam 'DestinationCidrBlock', '', type: 'String'
+    ComponentParam 'RouteTableIds', '', type: 'CommaDelimitedList'
+  end
+
+end

--- a/site-to-site-vpn.cfndsl.rb
+++ b/site-to-site-vpn.cfndsl.rb
@@ -1,0 +1,152 @@
+require 'json'
+CloudFormation do
+
+  EC2_VPNGateway(:VPGW) {
+    Tags [{ Key: 'Name', Value: FnSub("${EnvironmentName}-proxy-VPGW")}]
+    Type 'ipsec.1'
+    if external_parameters[:vpn_gateway_ASN]
+      AmazonSideAsn external_parameters[:vpn_gateway_ASN]
+    end
+  }
+
+  EC2_VPCGatewayAttachment(:VPGWAttachment) {
+    VpcId Ref('VPCId')
+    VpnGatewayId Ref(:VPGW)
+  }
+
+  EC2_CustomerGateway(:CustomerGateway) {
+    IpAddress Ref('CGWIpAddress')
+    Type 'ipsec.1'
+    BgpAsn external_parameters[:customer_gateway_bgpasn]
+    Tags [{ Key: 'Name', Value: FnSub("${EnvironmentName}-proxy-CGW")}]
+  }
+
+  EC2_VPNConnection(:VPNConnection) {
+    CustomerGatewayId Ref(:CustomerGateway)
+    Type 'ipsec.1'
+    VpnGatewayId Ref(:VPGW)
+    Tags [{ Key: 'Name', Value: FnSub("${EnvironmentName}-proxy-VPN")}]
+    if external_parameters[:static_routes_only]
+      StaticRoutesOnly external_parameters[:static_routes_only]
+    end
+
+    if external_parameters[:tunnel_options]
+      VpnTunnelOptionsSpecifications external_parameters[:tunnel_options]
+    end 
+  }
+
+  EC2_VPNGatewayRoutePropagation(:VPNGatewayRoutePropagation) {
+    DependsOn :VPGWAttachment
+    RouteTableIds Ref('RouteTableIds')
+    VpnGatewayId Ref(:VPGW)
+  }
+
+
+  if external_parameters[:static_routes_only]
+    EC2_VPNConnectionRoute(:VPNConnectionRoute) {
+      DestinationCidrBlock Ref('DestinationCidrBlock')
+      VpnConnectionId Ref(:VPNConnection)
+    }
+  end
+
+  if external_parameters[:tunnel_options_extended]
+    IAM_Role(:ccrTunnelOptionsRole) {
+      AssumeRolePolicyDocument({
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Principal: {
+              Service: [
+                'lambda.amazonaws.com'
+              ]
+            },
+            Action: 'sts:AssumeRole'
+          }
+        ]
+      })
+      Path '/'
+      Policies([
+        {
+          PolicyName: 'vpcConnectionConfig',
+          PolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: [
+                  'ec2:DescribeVpnConnections',
+                  'ec2:ModifyVpnTunnelOptions'
+                ],
+                Resource: '*'
+              },
+              {
+                Effect: 'Allow',
+                Action: [
+                  'logs:CreateLogGroup',
+                  'logs:CreateLogStream',
+                  'logs:PutLogEvents'
+                ],
+                Resource: '*'
+              }
+            ]
+          }
+        }
+      ])
+    }
+
+    Logs_LogGroup(:ccrTunnelOptionsLogGroup) {
+      LogGroupName FnSub("/aws/lambda/${ccrTunnelOptionsFunction}")
+      RetentionInDays 30
+    }
+
+    Lambda_Function(:ccrTunnelOptionsFunction) {
+      Code({
+        ZipFile: <<~CODE
+        import cfnresponse
+        import boto3
+        import logging
+        import time
+        import json
+        logger = logging.getLogger(__name__)
+        logger.setLevel(logging.INFO)
+        def lambda_handler(event, context):
+            try:
+                logger.info(event)
+                responseData = {}
+                client = boto3.client('ec2')
+                if event['RequestType'] in ['Create', 'Update']:
+                    logger.info(event['RequestType'])
+                    vpnConnectionId = event['ResourceProperties']['VpnConnectionId']
+                    response = client.describe_vpn_connections(VpnConnectionIds=[vpnConnectionId])
+                    outsideIps = [x['OutsideIpAddress'] for x in response['VpnConnections'][0]['VgwTelemetry']]
+                    tunnelOptions = json.loads(event['ResourceProperties']['TunnelOptions'])
+                    for outsideIp in outsideIps:
+                        waiter = client.get_waiter('vpn_connection_available')
+                        waiter.wait(VpnConnectionIds=[vpnConnectionId])
+                        response = client.modify_vpn_tunnel_options(VpnConnectionId=vpnConnectionId, VpnTunnelOutsideIpAddress=outsideIp, TunnelOptions=tunnelOptions)
+                elif event['RequestType'] == 'Delete':
+                    logger.info(event['RequestType'])
+                cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
+            except Exception as e:
+                logger.error('Failed to update vpn tunnel options', exc_info=True)
+                cfnresponse.send(event, context, cfnresponse.FAILED, {})
+        CODE
+      })
+      Handler "index.lambda_handler"
+      Runtime "python3.8"
+      Role FnGetAtt(:ccrTunnelOptionsRole, :Arn)
+      Timeout 600
+    }
+
+    Resource("TunnelOptions") {
+      Type "Custom::TunnelOption"
+      Property 'ServiceToken', FnGetAtt('ccrTunnelOptionsFunction', 'Arn')
+      Property 'VpnConnectionId', Ref(:VPNConnection)
+      Property 'TunnelOptions', external_parameters[:tunnel_options_extended].to_json
+    }
+
+
+  end
+
+end

--- a/site-to-site-vpn.config.yaml
+++ b/site-to-site-vpn.config.yaml
@@ -1,0 +1,68 @@
+customer_gateway_bgpasn: 65000
+#vpn_gateway_ASN:
+#static_routes_only: true
+
+tunnel_options:
+#  - PreSharedKey: ....
+#  - TunnelInsideCidr: ....
+
+# Setting on of the below tunnel options configurations will set that config for both tunnels.
+tunnel_options_extended:
+#  Phase1LifetimeSeconds: 28800
+#  Phase2LifetimeSeconds: 3600
+#  RekeyMarginTimeSeconds: 540
+#  RekeyFuzzPercentage: 100
+#  ReplayWindowSize: 1024
+#  DPDTimeoutSeconds: 30
+#  DPDTimeoutAction: clear
+#  StartupAction: add
+#  Phase1EncryptionAlgorithms:
+#    - Value: AES128
+#    - Value: AES256
+#    - Value: AES128-GCM-16
+#    - Value: AES256-GCM-16
+#  Phase2EncryptionAlgorithms:
+#    - Value: AES128
+#    - Value: AES256
+#    - Value: AES128-GCM-16
+#    - Value: AES256-GCM-16
+#  Phase1IntegrityAlgorithms:
+#    - Value: SHA1
+#    - Value: SHA2-256
+#    - Value: SHA2-384
+#    - Value: SHA2-512
+#  Phase2IntegrityAlgorithms:
+#    - Value: SHA1
+#    - Value: SHA2-256
+#    - Value: SHA2-384
+#    - Value: SHA2-512
+#  Phase1DHGroupNumbers:
+#    - Value: 2
+#    - Value: 14
+#    - Value: 15
+#    - Value: 16
+#    - Value: 17
+#    - Value: 18
+#    - Value: 19
+#    - Value: 20
+#    - Value: 21
+#    - Value: 22
+#    - Value: 23
+#    - Value: 24
+#  Phase2DHGroupNumbers:
+#    - Value: 2
+#    - Value: 5
+#    - Value: 14
+#    - Value: 15
+#    - Value: 16
+#    - Value: 17
+#    - Value: 18
+#    - Value: 19
+#    - Value: 20
+#    - Value: 21
+#    - Value: 22
+#    - Value: 23
+#    - Value: 24
+#  IKEVersions:
+#    - Value: ikev1
+#    - Value: ikev2

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,119 @@
+require 'yaml'
+
+describe 'compiled component site-to-site-vpn' do
+  
+  context 'cftest' do
+    it 'compiles test' do
+      expect(system("cfhighlander cftest #{@validate} --tests tests/default.test.yaml")).to be_truthy
+    end      
+  end
+  
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/default/site-to-site-vpn.compiled.yaml") }
+  
+  context "Resource" do
+
+    
+    context "VPGW" do
+      let(:resource) { template["Resources"]["VPGW"] }
+
+      it "is of type AWS::EC2::VPNGateway" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPNGateway")
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-proxy-VPGW"}}])
+      end
+      
+      it "to have property Type" do
+          expect(resource["Properties"]["Type"]).to eq("ipsec.1")
+      end
+      
+    end
+    
+    context "VPGWAttachment" do
+      let(:resource) { template["Resources"]["VPGWAttachment"] }
+
+      it "is of type AWS::EC2::VPCGatewayAttachment" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPCGatewayAttachment")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property VpnGatewayId" do
+          expect(resource["Properties"]["VpnGatewayId"]).to eq({"Ref"=>"VPGW"})
+      end
+      
+    end
+    
+    context "CustomerGateway" do
+      let(:resource) { template["Resources"]["CustomerGateway"] }
+
+      it "is of type AWS::EC2::CustomerGateway" do
+          expect(resource["Type"]).to eq("AWS::EC2::CustomerGateway")
+      end
+      
+      it "to have property IpAddress" do
+          expect(resource["Properties"]["IpAddress"]).to eq({"Ref"=>"CGWIpAddress"})
+      end
+      
+      it "to have property Type" do
+          expect(resource["Properties"]["Type"]).to eq("ipsec.1")
+      end
+      
+      it "to have property BgpAsn" do
+          expect(resource["Properties"]["BgpAsn"]).to eq(65000)
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-proxy-CGW"}}])
+      end
+      
+    end
+    
+    context "VPNConnection" do
+      let(:resource) { template["Resources"]["VPNConnection"] }
+
+      it "is of type AWS::EC2::VPNConnection" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPNConnection")
+      end
+      
+      it "to have property CustomerGatewayId" do
+          expect(resource["Properties"]["CustomerGatewayId"]).to eq({"Ref"=>"CustomerGateway"})
+      end
+      
+      it "to have property Type" do
+          expect(resource["Properties"]["Type"]).to eq("ipsec.1")
+      end
+      
+      it "to have property VpnGatewayId" do
+          expect(resource["Properties"]["VpnGatewayId"]).to eq({"Ref"=>"VPGW"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-proxy-VPN"}}])
+      end
+      
+    end
+    
+    context "VPNGatewayRoutePropagation" do
+      let(:resource) { template["Resources"]["VPNGatewayRoutePropagation"] }
+
+      it "is of type AWS::EC2::VPNGatewayRoutePropagation" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPNGatewayRoutePropagation")
+      end
+      
+      it "to have property RouteTableIds" do
+          expect(resource["Properties"]["RouteTableIds"]).to eq({"Ref"=>"RouteTableIds"})
+      end
+      
+      it "to have property VpnGatewayId" do
+          expect(resource["Properties"]["VpnGatewayId"]).to eq({"Ref"=>"VPGW"})
+      end
+      
+    end
+    
+  end
+
+end

--- a/spec/extended_tunnel_options_spec.rb
+++ b/spec/extended_tunnel_options_spec.rb
@@ -1,0 +1,207 @@
+require 'yaml'
+
+describe 'compiled component site-to-site-vpn' do
+  
+  context 'cftest' do
+    it 'compiles test' do
+      expect(system("cfhighlander cftest #{@validate} --tests tests/extended_tunnel_options.test.yaml")).to be_truthy
+    end      
+  end
+  
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/extended_tunnel_options/site-to-site-vpn.compiled.yaml") }
+  
+  context "Resource" do
+
+    
+    context "VPGW" do
+      let(:resource) { template["Resources"]["VPGW"] }
+
+      it "is of type AWS::EC2::VPNGateway" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPNGateway")
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-proxy-VPGW"}}])
+      end
+      
+      it "to have property Type" do
+          expect(resource["Properties"]["Type"]).to eq("ipsec.1")
+      end
+      
+    end
+    
+    context "VPGWAttachment" do
+      let(:resource) { template["Resources"]["VPGWAttachment"] }
+
+      it "is of type AWS::EC2::VPCGatewayAttachment" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPCGatewayAttachment")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property VpnGatewayId" do
+          expect(resource["Properties"]["VpnGatewayId"]).to eq({"Ref"=>"VPGW"})
+      end
+      
+    end
+    
+    context "CustomerGateway" do
+      let(:resource) { template["Resources"]["CustomerGateway"] }
+
+      it "is of type AWS::EC2::CustomerGateway" do
+          expect(resource["Type"]).to eq("AWS::EC2::CustomerGateway")
+      end
+      
+      it "to have property IpAddress" do
+          expect(resource["Properties"]["IpAddress"]).to eq({"Ref"=>"CGWIpAddress"})
+      end
+      
+      it "to have property Type" do
+          expect(resource["Properties"]["Type"]).to eq("ipsec.1")
+      end
+      
+      it "to have property BgpAsn" do
+          expect(resource["Properties"]["BgpAsn"]).to eq(65000)
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-proxy-CGW"}}])
+      end
+      
+    end
+    
+    context "VPNConnection" do
+      let(:resource) { template["Resources"]["VPNConnection"] }
+
+      it "is of type AWS::EC2::VPNConnection" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPNConnection")
+      end
+      
+      it "to have property CustomerGatewayId" do
+          expect(resource["Properties"]["CustomerGatewayId"]).to eq({"Ref"=>"CustomerGateway"})
+      end
+      
+      it "to have property Type" do
+          expect(resource["Properties"]["Type"]).to eq("ipsec.1")
+      end
+      
+      it "to have property VpnGatewayId" do
+          expect(resource["Properties"]["VpnGatewayId"]).to eq({"Ref"=>"VPGW"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-proxy-VPN"}}])
+      end
+      
+    end
+    
+    context "VPNGatewayRoutePropagation" do
+      let(:resource) { template["Resources"]["VPNGatewayRoutePropagation"] }
+
+      it "is of type AWS::EC2::VPNGatewayRoutePropagation" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPNGatewayRoutePropagation")
+      end
+      
+      it "to have property RouteTableIds" do
+          expect(resource["Properties"]["RouteTableIds"]).to eq({"Ref"=>"RouteTableIds"})
+      end
+      
+      it "to have property VpnGatewayId" do
+          expect(resource["Properties"]["VpnGatewayId"]).to eq({"Ref"=>"VPGW"})
+      end
+      
+    end
+    
+    context "ccrTunnelOptionsRole" do
+      let(:resource) { template["Resources"]["ccrTunnelOptionsRole"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>["lambda.amazonaws.com"]}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property Policies" do
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"vpcConnectionConfig", "PolicyDocument"=>{"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Action"=>["ec2:DescribeVpnConnections", "ec2:ModifyVpnTunnelOptions"], "Resource"=>"*"}, {"Effect"=>"Allow", "Action"=>["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"], "Resource"=>"*"}]}}])
+      end
+      
+    end
+    
+    context "ccrTunnelOptionsLogGroup" do
+      let(:resource) { template["Resources"]["ccrTunnelOptionsLogGroup"] }
+
+      it "is of type AWS::Logs::LogGroup" do
+          expect(resource["Type"]).to eq("AWS::Logs::LogGroup")
+      end
+      
+      it "to have property LogGroupName" do
+          expect(resource["Properties"]["LogGroupName"]).to eq({"Fn::Sub"=>"/aws/lambda/${ccrTunnelOptionsFunction}"})
+      end
+      
+      it "to have property RetentionInDays" do
+          expect(resource["Properties"]["RetentionInDays"]).to eq(30)
+      end
+      
+    end
+    
+    context "ccrTunnelOptionsFunction" do
+      let(:resource) { template["Resources"]["ccrTunnelOptionsFunction"] }
+
+      it "is of type AWS::Lambda::Function" do
+          expect(resource["Type"]).to eq("AWS::Lambda::Function")
+      end
+      
+      it "to have property Code" do
+          expect(resource["Properties"]["Code"]).to eq({"ZipFile"=>"import cfnresponse\nimport boto3\nimport logging\nimport time\nimport json\nlogger = logging.getLogger(__name__)\nlogger.setLevel(logging.INFO)\ndef lambda_handler(event, context):\n    try:\n        logger.info(event)\n        responseData = {}\n        client = boto3.client('ec2')\n        if event['RequestType'] in ['Create', 'Update']:\n            logger.info(event['RequestType'])\n            vpnConnectionId = event['ResourceProperties']['VpnConnectionId']\n            response = client.describe_vpn_connections(VpnConnectionIds=[vpnConnectionId])\n            outsideIps = [x['OutsideIpAddress'] for x in response['VpnConnections'][0]['VgwTelemetry']]\n            tunnelOptions = json.loads(event['ResourceProperties']['TunnelOptions'])\n            for outsideIp in outsideIps:\n                waiter = client.get_waiter('vpn_connection_available')\n                waiter.wait(VpnConnectionIds=[vpnConnectionId])\n                response = client.modify_vpn_tunnel_options(VpnConnectionId=vpnConnectionId, VpnTunnelOutsideIpAddress=outsideIp, TunnelOptions=tunnelOptions)\n        elif event['RequestType'] == 'Delete':\n            logger.info(event['RequestType'])\n        cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)\n    except Exception as e:\n        logger.error('Failed to update vpn tunnel options', exc_info=True)\n        cfnresponse.send(event, context, cfnresponse.FAILED, {})\n"})
+      end
+      
+      it "to have property Handler" do
+          expect(resource["Properties"]["Handler"]).to eq("index.lambda_handler")
+      end
+      
+      it "to have property Runtime" do
+          expect(resource["Properties"]["Runtime"]).to eq("python3.8")
+      end
+      
+      it "to have property Role" do
+          expect(resource["Properties"]["Role"]).to eq({"Fn::GetAtt"=>["ccrTunnelOptionsRole", "Arn"]})
+      end
+      
+      it "to have property Timeout" do
+          expect(resource["Properties"]["Timeout"]).to eq(600)
+      end
+      
+    end
+    
+    context "TunnelOptions" do
+      let(:resource) { template["Resources"]["TunnelOptions"] }
+
+      it "is of type Custom::TunnelOption" do
+          expect(resource["Type"]).to eq("Custom::TunnelOption")
+      end
+      
+      it "to have property ServiceToken" do
+          expect(resource["Properties"]["ServiceToken"]).to eq({"Fn::GetAtt"=>["ccrTunnelOptionsFunction", "Arn"]})
+      end
+      
+      it "to have property VpnConnectionId" do
+          expect(resource["Properties"]["VpnConnectionId"]).to eq({"Ref"=>"VPNConnection"})
+      end
+      
+      it "to have property TunnelOptions" do
+          expect(resource["Properties"]["TunnelOptions"]).to eq('{"Phase1LifetimeSeconds":28800,"Phase2LifetimeSeconds":3600,"RekeyMarginTimeSeconds":540,"RekeyFuzzPercentage":100,"ReplayWindowSize":1024,"DPDTimeoutSeconds":30,"DPDTimeoutAction":"clear","StartupAction":"add","Phase1EncryptionAlgorithms":[{"Value":"AES128"},{"Value":"AES256"},{"Value":"AES128-GCM-16"},{"Value":"AES256-GCM-16"}],"Phase2EncryptionAlgorithms":[{"Value":"AES128"},{"Value":"AES256"},{"Value":"AES128-GCM-16"},{"Value":"AES256-GCM-16"}],"Phase1IntegrityAlgorithms":[{"Value":"SHA1"},{"Value":"SHA2-256"},{"Value":"SHA2-384"},{"Value":"SHA2-512"}],"Phase2IntegrityAlgorithms":[{"Value":"SHA1"},{"Value":"SHA2-256"},{"Value":"SHA2-384"},{"Value":"SHA2-512"}],"Phase1DHGroupNumbers":[{"Value":2},{"Value":14},{"Value":15},{"Value":16},{"Value":17},{"Value":18},{"Value":19},{"Value":20},{"Value":21},{"Value":22},{"Value":23},{"Value":24}],"Phase2DHGroupNumbers":[{"Value":2},{"Value":5},{"Value":14},{"Value":15},{"Value":16},{"Value":17},{"Value":18},{"Value":19},{"Value":20},{"Value":21},{"Value":22},{"Value":23},{"Value":24}],"IKEVersions":[{"Value":"ikev1"},{"Value":"ikev2"}]}')
+      end
+      
+    end
+    
+  end
+
+end

--- a/spec/static_routes_spec.rb
+++ b/spec/static_routes_spec.rb
@@ -1,0 +1,140 @@
+require 'yaml'
+
+describe 'compiled component site-to-site-vpn' do
+  
+  context 'cftest' do
+    it 'compiles test' do
+      expect(system("cfhighlander cftest #{@validate} --tests tests/static_routes.test.yaml")).to be_truthy
+    end      
+  end
+  
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/static_routes/site-to-site-vpn.compiled.yaml") }
+  
+  context "Resource" do
+
+    
+    context "VPGW" do
+      let(:resource) { template["Resources"]["VPGW"] }
+
+      it "is of type AWS::EC2::VPNGateway" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPNGateway")
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-proxy-VPGW"}}])
+      end
+      
+      it "to have property Type" do
+          expect(resource["Properties"]["Type"]).to eq("ipsec.1")
+      end
+      
+    end
+    
+    context "VPGWAttachment" do
+      let(:resource) { template["Resources"]["VPGWAttachment"] }
+
+      it "is of type AWS::EC2::VPCGatewayAttachment" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPCGatewayAttachment")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property VpnGatewayId" do
+          expect(resource["Properties"]["VpnGatewayId"]).to eq({"Ref"=>"VPGW"})
+      end
+      
+    end
+    
+    context "CustomerGateway" do
+      let(:resource) { template["Resources"]["CustomerGateway"] }
+
+      it "is of type AWS::EC2::CustomerGateway" do
+          expect(resource["Type"]).to eq("AWS::EC2::CustomerGateway")
+      end
+      
+      it "to have property IpAddress" do
+          expect(resource["Properties"]["IpAddress"]).to eq({"Ref"=>"CGWIpAddress"})
+      end
+      
+      it "to have property Type" do
+          expect(resource["Properties"]["Type"]).to eq("ipsec.1")
+      end
+      
+      it "to have property BgpAsn" do
+          expect(resource["Properties"]["BgpAsn"]).to eq(65000)
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-proxy-CGW"}}])
+      end
+      
+    end
+    
+    context "VPNConnection" do
+      let(:resource) { template["Resources"]["VPNConnection"] }
+
+      it "is of type AWS::EC2::VPNConnection" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPNConnection")
+      end
+      
+      it "to have property CustomerGatewayId" do
+          expect(resource["Properties"]["CustomerGatewayId"]).to eq({"Ref"=>"CustomerGateway"})
+      end
+      
+      it "to have property Type" do
+          expect(resource["Properties"]["Type"]).to eq("ipsec.1")
+      end
+      
+      it "to have property VpnGatewayId" do
+          expect(resource["Properties"]["VpnGatewayId"]).to eq({"Ref"=>"VPGW"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-proxy-VPN"}}])
+      end
+      
+      it "to have property StaticRoutesOnly" do
+          expect(resource["Properties"]["StaticRoutesOnly"]).to eq(true)
+      end
+      
+    end
+    
+    context "VPNGatewayRoutePropagation" do
+      let(:resource) { template["Resources"]["VPNGatewayRoutePropagation"] }
+
+      it "is of type AWS::EC2::VPNGatewayRoutePropagation" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPNGatewayRoutePropagation")
+      end
+      
+      it "to have property RouteTableIds" do
+          expect(resource["Properties"]["RouteTableIds"]).to eq({"Ref"=>"RouteTableIds"})
+      end
+      
+      it "to have property VpnGatewayId" do
+          expect(resource["Properties"]["VpnGatewayId"]).to eq({"Ref"=>"VPGW"})
+      end
+      
+    end
+    
+    context "VPNConnectionRoute" do
+      let(:resource) { template["Resources"]["VPNConnectionRoute"] }
+
+      it "is of type AWS::EC2::VPNConnectionRoute" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPNConnectionRoute")
+      end
+      
+      it "to have property DestinationCidrBlock" do
+          expect(resource["Properties"]["DestinationCidrBlock"]).to eq({"Ref"=>"DestinationCidrBlock"})
+      end
+      
+      it "to have property VpnConnectionId" do
+          expect(resource["Properties"]["VpnConnectionId"]).to eq({"Ref"=>"VPNConnection"})
+      end
+      
+    end
+    
+  end
+
+end

--- a/spec/tunnel_options_spec.rb
+++ b/spec/tunnel_options_spec.rb
@@ -1,0 +1,123 @@
+require 'yaml'
+
+describe 'compiled component site-to-site-vpn' do
+  
+  context 'cftest' do
+    it 'compiles test' do
+      expect(system("cfhighlander cftest #{@validate} --tests tests/tunnel_options.test.yaml")).to be_truthy
+    end      
+  end
+  
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/tunnel_options/site-to-site-vpn.compiled.yaml") }
+  
+  context "Resource" do
+
+    
+    context "VPGW" do
+      let(:resource) { template["Resources"]["VPGW"] }
+
+      it "is of type AWS::EC2::VPNGateway" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPNGateway")
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-proxy-VPGW"}}])
+      end
+      
+      it "to have property Type" do
+          expect(resource["Properties"]["Type"]).to eq("ipsec.1")
+      end
+      
+    end
+    
+    context "VPGWAttachment" do
+      let(:resource) { template["Resources"]["VPGWAttachment"] }
+
+      it "is of type AWS::EC2::VPCGatewayAttachment" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPCGatewayAttachment")
+      end
+      
+      it "to have property VpcId" do
+          expect(resource["Properties"]["VpcId"]).to eq({"Ref"=>"VPCId"})
+      end
+      
+      it "to have property VpnGatewayId" do
+          expect(resource["Properties"]["VpnGatewayId"]).to eq({"Ref"=>"VPGW"})
+      end
+      
+    end
+    
+    context "CustomerGateway" do
+      let(:resource) { template["Resources"]["CustomerGateway"] }
+
+      it "is of type AWS::EC2::CustomerGateway" do
+          expect(resource["Type"]).to eq("AWS::EC2::CustomerGateway")
+      end
+      
+      it "to have property IpAddress" do
+          expect(resource["Properties"]["IpAddress"]).to eq({"Ref"=>"CGWIpAddress"})
+      end
+      
+      it "to have property Type" do
+          expect(resource["Properties"]["Type"]).to eq("ipsec.1")
+      end
+      
+      it "to have property BgpAsn" do
+          expect(resource["Properties"]["BgpAsn"]).to eq(65000)
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-proxy-CGW"}}])
+      end
+      
+    end
+    
+    context "VPNConnection" do
+      let(:resource) { template["Resources"]["VPNConnection"] }
+
+      it "is of type AWS::EC2::VPNConnection" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPNConnection")
+      end
+      
+      it "to have property CustomerGatewayId" do
+          expect(resource["Properties"]["CustomerGatewayId"]).to eq({"Ref"=>"CustomerGateway"})
+      end
+      
+      it "to have property Type" do
+          expect(resource["Properties"]["Type"]).to eq("ipsec.1")
+      end
+      
+      it "to have property VpnGatewayId" do
+          expect(resource["Properties"]["VpnGatewayId"]).to eq({"Ref"=>"VPGW"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-proxy-VPN"}}])
+      end
+      
+      it "to have property VpnTunnelOptionsSpecifications" do
+          expect(resource["Properties"]["VpnTunnelOptionsSpecifications"]).to eq([{"PreSharedKey"=>"{{resolve:ssm:/environment/vpn/PreSharedKey:1}}"}, {"TunnelInsideCidr"=>"169.254.216.196/30"}])
+      end
+      
+    end
+    
+    context "VPNGatewayRoutePropagation" do
+      let(:resource) { template["Resources"]["VPNGatewayRoutePropagation"] }
+
+      it "is of type AWS::EC2::VPNGatewayRoutePropagation" do
+          expect(resource["Type"]).to eq("AWS::EC2::VPNGatewayRoutePropagation")
+      end
+      
+      it "to have property RouteTableIds" do
+          expect(resource["Properties"]["RouteTableIds"]).to eq({"Ref"=>"RouteTableIds"})
+      end
+      
+      it "to have property VpnGatewayId" do
+          expect(resource["Properties"]["VpnGatewayId"]).to eq({"Ref"=>"VPGW"})
+      end
+      
+    end
+    
+  end
+
+end

--- a/tests/default.test.yaml
+++ b/tests/default.test.yaml
@@ -1,0 +1,6 @@
+test_metadata:
+  type: config
+  name: default
+  description: default test for site-to-site vpn
+
+customer_gateway_bgpasn: 65000

--- a/tests/extended_tunnel_options.test.yaml
+++ b/tests/extended_tunnel_options.test.yaml
@@ -1,0 +1,66 @@
+test_metadata:
+  type: config
+  name: extended_tunnel_options
+  description: set cloudformation unsupported tunnel options via CR
+
+customer_gateway_bgpasn: 65000
+
+tunnel_options_extended:
+  Phase1LifetimeSeconds: 28800
+  Phase2LifetimeSeconds: 3600
+  RekeyMarginTimeSeconds: 540
+  RekeyFuzzPercentage: 100
+  ReplayWindowSize: 1024
+  DPDTimeoutSeconds: 30
+  DPDTimeoutAction: clear
+  StartupAction: add
+  Phase1EncryptionAlgorithms:
+    - Value: AES128
+    - Value: AES256
+    - Value: AES128-GCM-16
+    - Value: AES256-GCM-16
+  Phase2EncryptionAlgorithms:
+    - Value: AES128
+    - Value: AES256
+    - Value: AES128-GCM-16
+    - Value: AES256-GCM-16
+  Phase1IntegrityAlgorithms:
+    - Value: SHA1
+    - Value: SHA2-256
+    - Value: SHA2-384
+    - Value: SHA2-512
+  Phase2IntegrityAlgorithms:
+    - Value: SHA1
+    - Value: SHA2-256
+    - Value: SHA2-384
+    - Value: SHA2-512
+  Phase1DHGroupNumbers:
+    - Value: 2
+    - Value: 14
+    - Value: 15
+    - Value: 16
+    - Value: 17
+    - Value: 18
+    - Value: 19
+    - Value: 20
+    - Value: 21
+    - Value: 22
+    - Value: 23
+    - Value: 24
+  Phase2DHGroupNumbers:
+    - Value: 2
+    - Value: 5
+    - Value: 14
+    - Value: 15
+    - Value: 16
+    - Value: 17
+    - Value: 18
+    - Value: 19
+    - Value: 20
+    - Value: 21
+    - Value: 22
+    - Value: 23
+    - Value: 24
+  IKEVersions:
+    - Value: ikev1
+    - Value: ikev2

--- a/tests/static_routes.test.yaml
+++ b/tests/static_routes.test.yaml
@@ -1,0 +1,7 @@
+test_metadata:
+  type: config
+  name: static_routes
+  description: use static routes 
+
+customer_gateway_bgpasn: 65000
+static_routes_only: true

--- a/tests/tunnel_options.test.yaml
+++ b/tests/tunnel_options.test.yaml
@@ -1,0 +1,10 @@
+test_metadata:
+  type: config
+  name: tunnel_options
+  description: set cloudformation supported tunnel options
+
+customer_gateway_bgpasn: 65000
+
+tunnel_options:
+  - PreSharedKey: '{{resolve:ssm:/environment/vpn/PreSharedKey:1}}'
+  - TunnelInsideCidr: '169.254.216.196/30'


### PR DESCRIPTION
Creates aws site-to-site vpn.
Custom resource lambda created for setting tunnel options not currently supported in cloudformation.
